### PR TITLE
Update diff-content-length.java

### DIFF
--- a/response-filters/diff-content-length.java
+++ b/response-filters/diff-content-length.java
@@ -6,7 +6,7 @@
     Filter for responses with incorrect Content-Length.
 */
 
-if(!requestResponse.hasResponse() || requestResponse.response().hasHeader("Content-Length")) {
+if(!requestResponse.hasResponse() || !requestResponse.response().hasHeader("Content-Length")) {
   return false;
 }
 


### PR DESCRIPTION
The if statement returns false only if either of these conditions (line 9) is true, meaning that it returns false if there is no response or if the response has a "Content-Length" header.

However, based on the use case of filtering for responses with incorrect "Content-Length," it seems like you want to return false when there is no response or when there is no "Content-Length" header.